### PR TITLE
ApacheDS now only provides M20 and M21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+services:
+  - docker
+script:
+    - docker build -t apacheds-test .

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 # ApacheDS installation
 #############################################
 
-ENV APACHEDS_VERSION 2.0.0-M19
+ENV APACHEDS_VERSION 2.0.0-M21
 ENV APACHEDS_ARCH amd64
 
 ENV APACHEDS_ARCHIVE apacheds-${APACHEDS_VERSION}-${APACHEDS_ARCH}.deb


### PR DESCRIPTION
The mirror (http://www.eu.apache.org/dist//directory/apacheds/dist/)
was last updated on the 21st of December. Since then, no M19 has been
available.
