### PR TITLE
Bump to 2.0.0-M23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 # ApacheDS installation
 #############################################
 
-ENV APACHEDS_VERSION 2.0.0-M21
+ENV APACHEDS_VERSION 2.0.0-M23
 ENV APACHEDS_ARCH amd64
 
 ENV APACHEDS_ARCHIVE apacheds-${APACHEDS_VERSION}-${APACHEDS_ARCH}.deb


### PR DESCRIPTION
[Builds](https://hub.docker.com/r/openmicroscopy/apacheds/builds/bkeqdde2p7wwrh4qbnnsvqd/) are currently failing since M21 has been removed from the repos. Bumping to M23.