### PR TITLE
ldapmanager: add `password` command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ script:
     - bin/ldapmanager group public --member public
     - bin/ldapmanager get 'uid=public,ou=Users,dc=openmicroscopy,dc=org'
     - bin/ldapmanager search 'uid=public'
-    - bin/ldapmanager search
+    - bin/ldapmanager --bind-user uid=public,ou=Users,dc=openmicroscopy,dc=org --bind-pass public search
+    - bin/ldapmanager --bind-user uid=public,ou=Users,dc=openmicroscopy,dc=org --bind-pass public password public --password first --password second
+    - bin/ldapmanager --bind-user uid=public,ou=Users,dc=openmicroscopy,dc=org --bind-pass first search
+    - bin/ldapmanager --bind-user uid=public,ou=Users,dc=openmicroscopy,dc=org --bind-pass second search
     - bin/ldapmanager clear
     - docker rm -f apacheds-test

--- a/bin/ldapmanager
+++ b/bin/ldapmanager
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import argparse
+import getpass
+import fileinput
 import ldap
 import ldap.modlist
 import ldif
@@ -13,8 +15,11 @@ Example
 -------
     ./ldapmanager init
     ./ldapmanager user u1
-    ./ldapmanager user u2
-    ./ldapmanager user u3
+    ./ldapmanager user u2 --first Jane --last Schmidt
+    ./ldapmanager user u3 --password example
+    ./ldapmanager password u1  # Requires input
+    ./ldapmanager password u1 --password secret
+    echo secret | ./ldapmanager password u1 -f-
     ./ldapmanager group g1 --member u1 --owner u2 --owner -u3
     ./ldapmanager member g1 u1 --remove
     ./ldapmanager owner g1 u2 --remove
@@ -69,6 +74,14 @@ def main():
         "If no DN is set, login and base will be used"))
     user.add_argument("--mail", default=None, help=(
         "If no mail address is iset, login and base will be used"))
+
+    # Password ################################################################
+    password = subparsers.add_parser("password")
+    password.set_defaults(func=_password)
+    password.add_argument("user", metavar="USER")
+    password.add_argument("--append", "-a", action="store_true")
+    password.add_argument("--password", "-p", default=None, action="append")
+    password.add_argument("--file", "-f", default=None, action="append")
 
     # Group ###################################################################
     group = subparsers.add_parser("group")
@@ -264,6 +277,26 @@ def _user(ns):
     if ns.password:
         modlist["userPassword"] = ns.password
     process(ns, ns.dn, modlist)
+
+def _password(ns):
+    cleanup(ns)
+
+    passwords = []
+    if ns.password:
+        passwords.extend(ns.password)
+    if ns.file:
+        for line in fileinput.input(ns.file):
+            passwords.append(line.strip())
+
+    if not passwords:
+        passwords.append(getpass.getpass())
+
+    dn = dn_user(ns, ns.user)
+    if ns.append:
+        modlist = [(ldap.MOD_ADD, 'userPassword', passwords)]
+    else:
+        modlist = [(ldap.MOD_REPLACE, 'userPassword', passwords)]
+    process(ns, dn, modlist, action="modify")
 
 
 def _group(ns):


### PR DESCRIPTION
Supports:
 * replacing current password with one or more passwords
 * OR appending one or more passwords (see `--append`)

 Passwords can be retrieved from:
 * secure user entry using `getpass`; or
 * one or more files including stdin; or
 * one or hard-coded command-line arguments

Closing. See gh-9