### PR TITLE
Fix #24 Custom dc not working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN chown ${APACHEDS_USER}:${APACHEDS_GROUP} /run.sh \
     && chmod u+rx /run.sh
 
 ADD instance/* ${APACHEDS_BOOTSTRAP}/conf/
+RUN sed -i "s/ads-contextentry:: [A-Za-z0-9\+\=\/]*/ads-contextentry:: $(base64 -w 0 $APACHEDS_BOOTSTRAP/conf/ads-contextentry.decoded)/g" /$APACHEDS_BOOTSTRAP/conf/config.ldif
 ADD ome.ldif ${APACHEDS_BOOTSTRAP}/
 RUN mkdir ${APACHEDS_BOOTSTRAP}/cache \
     && mkdir ${APACHEDS_BOOTSTRAP}/run \

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Also other services are possible. For further information read the [configuratio
 
 ### Custom Root DC
 
-To customize the existing configuration with a different root DC you need to find a replace a number of strings within `ome.ldfi`, `instance/config.ldif` and `instance/ads-contextentry.decoded`. Specifically find and replace `dc=org`, `dc: org`, `openmicroscopy.org` and `openmicroscopy`.
+To customize the existing configuration with a different root DC you need to find and replace a number of strings within `ome.ldif`, `instance/config.ldif` and `instance/ads-contextentry.decoded`. Specifically find and replace `dc=org`, `dc: org`, `openmicroscopy.org` and `openmicroscopy`.
 
 For a custom root dc of `example.com`:
 

--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ $ sed -i 's/dc=org/dc=com/g' ome.ldif ./instance/config.ldif ./instance/ads-cont
 $ sed -i 's/dc: org/dc: com/g' ome.ldif ./instance/config.ldif ./instance/ads-contextentry.decoded
 ```
 
-Then [build](##-Build), [install](##-Installation) and [use](##-Usage) as your normally would.
+Then [build](##-Build), [install](##-Installation) and [use](##-Usage) as you normally would.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,29 @@ It would be possible to use this ApacheDS image to provide a [Kerberos server](h
 
 Also other services are possible. For further information read the [configuration documentation](https://directory.apache.org/apacheds/advanced-ug/2.1-config-description.html).
 
+### Same configuration with different root DC
+
+To customize the existing configuration with your own root DC.
+
+1. Find and replace a number of instances of 
+  a. `dc=org` and `dc: org` within the files `ome.ldfi`, `./instance/config.ldif` an `./instance/ads-contextentry.decoded`.
+  b. `openmicroscopy.org` within the files `ome.ldfi`, `./instance/config.ldif` an `./instance/ads-contextentry.decoded`.
+  c. `openmicroscopy` within the files `ome.ldfi`, `./instance/config.ldif` an `./instance/ads-contextentry.decoded`.
+2. Build the container
+
+For a custom root dc of `example.com`:
+
+```
+$ sed -i 's/openmicroscopy/example/g' ome.ldif ./instance/config.ldif ./instance/ads-contextentry.decoded
+$ sed -i 's/dc=org/dc=com/g' ome.ldif ./instance/config.ldif ./instance/ads-contextentry.decoded
+$ sed -i 's/dc: org/dc: com/g' ome.ldif ./instance/config.ldif ./instance/ads-contextentry.decoded
+$ docker build . -t example/apacheds
+...
+Successfully tagged example/apacheds:latest
+$ docker run -d -p 389:10389 --name apacheds -e LDAP_DOMAIN=example.com -v ./instance:/bootstrap/conf example/apacheds
+...
+Starting ApacheDS - default...
+[12:15:44] WARN [org.apache.directory.server.core.DefaultDirectoryService] - You didn't change the admin password of directory service instance 'default'.  Please update the admin password as soon as possible to prevent a possible security breach.
+```
+
+

--- a/README.md
+++ b/README.md
@@ -42,28 +42,16 @@ It would be possible to use this ApacheDS image to provide a [Kerberos server](h
 
 Also other services are possible. For further information read the [configuration documentation](https://directory.apache.org/apacheds/advanced-ug/2.1-config-description.html).
 
-### Same configuration with different root DC
+### Custom Root DC
 
-To customize the existing configuration with your own root DC.
-
-1. Find and replace a number of instances of 
-  a. `dc=org` and `dc: org` within the files `ome.ldfi`, `./instance/config.ldif` an `./instance/ads-contextentry.decoded`.
-  b. `openmicroscopy.org` within the files `ome.ldfi`, `./instance/config.ldif` an `./instance/ads-contextentry.decoded`.
-  c. `openmicroscopy` within the files `ome.ldfi`, `./instance/config.ldif` an `./instance/ads-contextentry.decoded`.
-2. Build the container
+To customize the existing configuration with a different root DC you need to find a replace a number of strings within `ome.ldfi`, `instance/config.ldif` and `instance/ads-contextentry.decoded`. Specifically find and replace `dc=org`, `dc: org`, `openmicroscopy.org` and `openmicroscopy`.
 
 For a custom root dc of `example.com`:
 
-```bash
+```shell
 $ sed -i 's/openmicroscopy/example/g' ome.ldif ./instance/config.ldif ./instance/ads-contextentry.decoded
 $ sed -i 's/dc=org/dc=com/g' ome.ldif ./instance/config.ldif ./instance/ads-contextentry.decoded
 $ sed -i 's/dc: org/dc: com/g' ome.ldif ./instance/config.ldif ./instance/ads-contextentry.decoded
-$ docker build . -t example/apacheds
-...
-Successfully tagged example/apacheds:latest
-$ docker run -d -p 389:10389 --name apacheds -e LDAP_DOMAIN=example.com -v ./instance:/bootstrap/conf example/apacheds
-...
-Starting ApacheDS - default...
-[12:15:44] WARN [org.apache.directory.server.core.DefaultDirectoryService] - You didn't change the admin password of directory service instance 'default'.  Please update the admin password as soon as possible to prevent a possible security breach.
-...
 ```
+
+Then [build](##-Build), [install](##-Installation) and [use](##-Usage) as your normally would.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To customize the existing configuration with your own root DC.
 
 For a custom root dc of `example.com`:
 
-```
+```bash
 $ sed -i 's/openmicroscopy/example/g' ome.ldif ./instance/config.ldif ./instance/ads-contextentry.decoded
 $ sed -i 's/dc=org/dc=com/g' ome.ldif ./instance/config.ldif ./instance/ads-contextentry.decoded
 $ sed -i 's/dc: org/dc: com/g' ome.ldif ./instance/config.ldif ./instance/ads-contextentry.decoded
@@ -65,6 +65,5 @@ $ docker run -d -p 389:10389 --name apacheds -e LDAP_DOMAIN=example.com -v ./ins
 ...
 Starting ApacheDS - default...
 [12:15:44] WARN [org.apache.directory.server.core.DefaultDirectoryService] - You didn't change the admin password of directory service instance 'default'.  Please update the admin password as soon as possible to prevent a possible security breach.
+...
 ```
-
-

--- a/instance/ads-contextentry.decoded
+++ b/instance/ads-contextentry.decoded
@@ -1,0 +1,4 @@
+dn: dc=openmicroscopy,dc=org
+dc: openmicroscopy
+objectclass: domain
+objectclass: top


### PR DESCRIPTION
I was trying to rebuild this for a custom dc and ran into #24.

So I added a file `./instance/ads-contextentry.decoded` that can be edited before a build. A Dockerfile command takes the file and base64 encodes and inserts into the correct place within the config.ldif file.