### PR TITLE
README: clarify the two ways to customize the ApacheDS image

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,13 @@ Then you can import entries into that partition via your own *ldif* file:
 
 ## Customization
 
-It is also possible to start up your own defined Apache DS *instance* with your own configuration for *partitions* and *services*. Therefore you need to mount your [config.ldif](https://github.com/openmicroscopy/apacheds-docker/blob/master/instance/config.ldif) file and set the *APACHEDS_INSTANCE* environment variable properly. In the provided sample configuration the instance is named *default*. Assuming your custom instance is called *yourinstance* the following command will do the trick:
-
-    docker run --name ldap -d -p 389:10389 -e APACHEDS_INSTANCE=yourinstance -v /path/to/your/config.ldif:/bootstrap/conf/config.ldif:ro openmicroscopy/apacheds
-
-
-It would be possible to use this ApacheDS image to provide a [Kerberos server](https://directory.apache.org/apacheds/advanced-ug/2.1-config-description.html#kerberos-server) as well. Just provide your own *config.ldif* file for that. Don't forget to expose the right port, then.
-
-Also other services are possible. For further information read the [configuration documentation](https://directory.apache.org/apacheds/advanced-ug/2.1-config-description.html).
-
 ### Custom Root DC
 
-To customize the existing configuration with a different root DC you need to find and replace a number of strings within `ome.ldif`, `instance/config.ldif` and `instance/ads-contextentry.decoded`. Specifically find and replace `dc=org`, `dc: org`, `openmicroscopy.org` and `openmicroscopy`.
+This image uses `openmicroscopy.org` as the root DC. To customize Apache with a different root DC, you will need
+to extend and rebuild your image.
 
-For a custom root dc of `example.com`:
+First find and replace a number of strings within `ome.ldif`, `instance/config.ldif` and `instance/ads-contextentry.decoded`.
+Specifically find and replace `dc=org`, `dc: org`, `openmicroscopy.org` and `openmicroscopy` e.g for a custom root DC of `example.com`:
 
 ```shell
 $ sed -i 's/openmicroscopy/example/g' ome.ldif ./instance/config.ldif ./instance/ads-contextentry.decoded
@@ -55,3 +48,19 @@ $ sed -i 's/dc: org/dc: com/g' ome.ldif ./instance/config.ldif ./instance/ads-co
 ```
 
 Then [build](##-Build), [install](##-Installation) and [use](##-Usage) as you normally would.
+
+### Custom Apache DS instances
+
+It is also possible to start up your own defined Apache DS *instance* with your own configuration for *partitions* and *services* - see
+[the ApacheDS documentation](https://directory.apache.org/apacheds/advanced-ug/2.1-config-description.html) for more details.
+Yu need to mount your `config.ldif` replacing the [default](https://github.com/openmicroscopy/apacheds-docker/blob/master/instance/config.ldif)
+and set the *APACHEDS_INSTANCE* environment variable properly.
+
+In the provided sample configuration, the instance is named *default*. Assuming your custom instance is called *yourinstance* the following command will do the trick:
+
+    docker run --name ldap -d -p 389:10389 -e APACHEDS_INSTANCE=yourinstance -v /path/to/your/config.ldif:/bootstrap/conf/config.ldif:ro openmicroscopy/apacheds
+
+
+It would be possible to use this ApacheDS image to provide a [Kerberos server](https://directory.apache.org/apacheds/advanced-ug/2.1-config-description.html#kerberos-server) as well. Just provide your own *config.ldif* file for that. Don't forget to expose the right port, then.
+
+Also other services are possible. For further information read the [configuration documentation](https://directory.apache.org/apacheds/advanced-ug/2.1-config-description.html).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then [build](##-Build), [install](##-Installation) and [use](##-Usage) as you no
 
 It is also possible to start up your own defined Apache DS *instance* with your own configuration for *partitions* and *services* - see
 [the ApacheDS documentation](https://directory.apache.org/apacheds/advanced-ug/2.1-config-description.html) for more details.
-Yu need to mount your `config.ldif` replacing the [default](https://github.com/openmicroscopy/apacheds-docker/blob/master/instance/config.ldif)
+You need to mount your `config.ldif` replacing the [default](https://github.com/openmicroscopy/apacheds-docker/blob/master/instance/config.ldif)
 and set the *APACHEDS_INSTANCE* environment variable properly.
 
 In the provided sample configuration, the instance is named *default*. Assuming your custom instance is called *yourinstance* the following command will do the trick:


### PR DESCRIPTION
Fixes #29

Addresses several unclarities raised in #29 by:
- creating another sub-section for the custom instance workflow 
- adding some links to the official documentation for the instance configuration
- explicitly mentioning the custom root DC workflow requires extension & rebuilding