### PR TITLE
Fixes for ApacheDS 2.0.0.AM27 and Ubuntu:20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,14 +72,12 @@ ADD bin/ldapmanager /usr/local/bin/ldapmanager
 # ApacheDS wrapper command
 #############################################
 
-RUN mv /opt/apacheds-${APACHEDS_SNAPSHOT} /opt/apacheds-${APACHEDS_VERSION}
-
 # Correct for hard-coded INSTANCES_DIRECTORY variable
-RUN sed -i "s#/var/lib/apacheds-${APACHEDS_VERSION}#/var/lib/apacheds#" /opt/apacheds-${APACHEDS_VERSION}/bin/apacheds
+RUN sed -i "s#/var/lib/apacheds-${APACHEDS_VERSION}#/var/lib/apacheds#" /opt/apacheds-${APACHEDS_SNAPSHOT}/bin/apacheds
 
 
 RUN curl -L -o /usr/local/bin/dumb-init \
     https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64 && \
     chmod +x /usr/local/bin/dumb-init
 
-ENTRYPOINT ["/run.sh"]
+# ENTRYPOINT ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,8 @@ RUN mkdir ${APACHEDS_BOOTSTRAP}/cache \
     && mkdir ${APACHEDS_BOOTSTRAP}/partitions \
     && chown -R ${APACHEDS_USER}:${APACHEDS_GROUP} ${APACHEDS_BOOTSTRAP}
 
-RUN apt-get install -y pip python-dev libldap2-dev libsasl2-dev libssl-dev
+RUN apt-get install -y pip
+RUN apt-get install -y python-dev libldap2-dev libsasl2-dev libssl-dev
 RUN pip install python-ldap
 ADD bin/ldapmanager /usr/local/bin/ldapmanager
 
@@ -80,4 +81,4 @@ RUN curl -L -o /usr/local/bin/dumb-init \
     https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64 && \
     chmod +x /usr/local/bin/dumb-init
 
-# ENTRYPOINT ["/run.sh"]
+ENTRYPOINT ["/run.sh"]

--- a/README.md
+++ b/README.md
@@ -8,14 +8,18 @@ The project sources can be found on [GitHub](https://github.com/openmicroscopy/a
 ## Build
 
     git clone https://github.com/openmicroscopy/apacheds-docker.git
-    docker build -t openmicroscopy/apacheds:2.0.0.AM26 apacheds-docker
+    docker build -t openmicroscopy/apacheds:2.0.0.AM27 apacheds-docker
 
 
 ## Installation
 
 The folder */var/lib/apacheds* contains the runtime data and thus has been defined as a volume. The image uses exactly the file system structure defined by the [ApacheDS documentation](https://directory.apache.org/apacheds/advanced-ug/2.2.1-debian-instance-layout.html).
 
-The container can be started issuing the following command:
+The local container that was built in the previous steps by issing the following command:
+
+    docker run --name ldap --platform linux/amd64 -dit -p 389:10389 openmicroscopy/apacheds:2.0.0.AM27
+
+The container can be started using a pre-built remote image by issuing the following command:
 
     docker run --name ldap --platform linux/amd64  -d -p 389:10389 openmicroscopy/apacheds
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,15 @@ The project sources can be found on [GitHub](https://github.com/openmicroscopy/a
 
 The folder */var/lib/apacheds* contains the runtime data and thus has been defined as a volume. The image uses exactly the file system structure defined by the [ApacheDS documentation](https://directory.apache.org/apacheds/advanced-ug/2.2.1-debian-instance-layout.html).
 
-The local container that was built in the previous steps by issing the following command:
+### Run by Local Image
+
+Create and run a container using the image that was built in the previous steps:
 
     docker run --name ldap --platform linux/amd64 -dit -p 389:10389 openmicroscopy/apacheds:2.0.0.AM27
 
-The container can be started using a pre-built remote image by issuing the following command:
+### Run by Remote Image
+
+Alternatively, you can create and run a container using a pre-built remote image:
 
     docker run --name ldap --platform linux/amd64  -d -p 389:10389 openmicroscopy/apacheds
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The folder */var/lib/apacheds* contains the runtime data and thus has been defin
 
 The container can be started issuing the following command:
 
-    docker run --name ldap -d -p 389:10389 openmicroscopy/apacheds
+    docker run --name ldap --platform linux/amd64  -d -p 389:10389 openmicroscopy/apacheds
 
 
 ## Usage

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -8,8 +8,8 @@
 # APACHEDS_USER
 # APACHEDS_GROUP
 
-APACHEDS_INSTANCE_DIRECTORY=${APACHEDS_DATA}/${APACHEDS_INSTANCE}
-PIDFILE="${APACHEDS_INSTANCE_DIRECTORY}/run/apacheds-${APACHEDS_INSTANCE}.pid"
+export APACHEDS_INSTANCE_DIRECTORY=${APACHEDS_DATA}-${APACHEDS_SNAPSHOT}
+export PIDFILE="${APACHEDS_INSTANCE_DIRECTORY}/default/run/apacheds-${APACHEDS_INSTANCE}.pid"
 
 # When a fresh data folder is detected then bootstrap the instance configuration.
 if [ ! -d ${APACHEDS_INSTANCE_DIRECTORY} ]; then
@@ -29,13 +29,13 @@ cleanup(){
 trap cleanup EXIT
 cleanup
 
-/opt/apacheds-${APACHEDS_VERSION}/bin/apacheds start ${APACHEDS_INSTANCE}
+/opt/apacheds-${APACHEDS_SNAPSHOT}/bin/apacheds start ${APACHEDS_INSTANCE}
 sleep 2  # Wait on new pid
 
 shutdown(){
     echo "Shutting down..."
-    /opt/apacheds-${APACHEDS_VERSION}/bin/apacheds stop ${APACHEDS_INSTANCE}
+    /opt/apacheds-${APACHEDS_SNAPSHOT}/bin/apacheds stop ${APACHEDS_INSTANCE}
 }
 
 trap shutdown INT TERM
-tail -n 0 --pid=$(cat $PIDFILE) -f ${APACHEDS_INSTANCE_DIRECTORY}/log/apacheds.log
+tail -n 0 --pid=$(cat $PIDFILE) -f ${APACHEDS_INSTANCE_DIRECTORY}/default/log/apacheds.log


### PR DESCRIPTION
This PR ensures that the Dockerfile can be built successfully. I made these changes because I was not able to build the base Image/Container upon cloning this repo.

Change Summary:
- Uses linux/amd64 emulation by default
- Uses ApacheDS version 2.0.0.AM27 (partly because version 2.0.0.AM26 couldn't be found at the previously hardcoded URL)
- Updates environment variables to use 2.0.0.AM28-SNAPSHOT (which is installed by 2.0.0.AM27)
- Fixes file paths broken by version upgrade
- Splits up a few build steps that have trouble completing on their own
- Installs python-ldap using pip (because apt-get wouldn't work). Installs necessary dependencies