### PR TITLE
Fix download link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
        openjdk-8-jre-headless \
        curl \
        jq \
-    && curl https://downloads.apache.org/directory/apacheds/dist/${APACHEDS_VERSION}/${APACHEDS_ARCHIVE} > ${APACHEDS_ARCHIVE} \
+    && curl https://archive.apache.org/dist/directory/apacheds/dist/${APACHEDS_VERSION}/${APACHEDS_ARCHIVE} > ${APACHEDS_ARCHIVE} \
     && dpkg -i ${APACHEDS_ARCHIVE} \
     && rm ${APACHEDS_ARCHIVE}
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -13,10 +13,13 @@ PIDFILE="${APACHEDS_INSTANCE_DIRECTORY}/run/apacheds-${APACHEDS_INSTANCE}.pid"
 
 # When a fresh data folder is detected then bootstrap the instance configuration.
 if [ ! -d ${APACHEDS_INSTANCE_DIRECTORY} ]; then
+    echo "Create instance directory"
     mkdir ${APACHEDS_INSTANCE_DIRECTORY}
-    cp -rv ${APACHEDS_BOOTSTRAP}/* ${APACHEDS_INSTANCE_DIRECTORY}
-    chown -v -R ${APACHEDS_USER}:${APACHEDS_GROUP} ${APACHEDS_INSTANCE_DIRECTORY}
 fi
+
+echo "Bootstrap config"
+cp -Rv ${APACHEDS_BOOTSTRAP}/* ${APACHEDS_INSTANCE_DIRECTORY}
+chown -v -R ${APACHEDS_USER}:${APACHEDS_GROUP} ${APACHEDS_INSTANCE_DIRECTORY}
 
 cleanup(){
     if [ -e "${PIDFILE}" ];

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -13,13 +13,10 @@ PIDFILE="${APACHEDS_INSTANCE_DIRECTORY}/run/apacheds-${APACHEDS_INSTANCE}.pid"
 
 # When a fresh data folder is detected then bootstrap the instance configuration.
 if [ ! -d ${APACHEDS_INSTANCE_DIRECTORY} ]; then
-    echo "Create instance directory"
     mkdir ${APACHEDS_INSTANCE_DIRECTORY}
+    cp -rv ${APACHEDS_BOOTSTRAP}/* ${APACHEDS_INSTANCE_DIRECTORY}
+    chown -v -R ${APACHEDS_USER}:${APACHEDS_GROUP} ${APACHEDS_INSTANCE_DIRECTORY}
 fi
-
-echo "Bootstrap config"
-cp -Rv ${APACHEDS_BOOTSTRAP}/* ${APACHEDS_INSTANCE_DIRECTORY}
-chown -v -R ${APACHEDS_USER}:${APACHEDS_GROUP} ${APACHEDS_INSTANCE_DIRECTORY}
 
 cleanup(){
     if [ -e "${PIDFILE}" ];


### PR DESCRIPTION
Unfortunately building the image is currently not possible, ~~furthermore bootstrapping does not work either.~~
Kindly refer the following pull request, proposed change:

- Fix the download link for `ApacheDS` as the former link is not longer available
  - Former (**dead**) link: https://downloads.apache.org/directory/apacheds/dist/2.0.0.AM26/apacheds-2.0.0AM26-amd64.deb
  - Changed link to: https://archive.apache.org/dist/directory/apacheds/dist/2.0.0.AM26/apacheds-2.0.0.AM26-amd64.deb
<del>

- Extract bootstrapping process from the directory creation process
  - Running the container does not trigger the bootstrapping process, thus resulting in a default root dc `dc=example,dc=com` (I expected `dc=openmicroscopy,dc=org`) 
  - Instead create the instance directory as necessary and always bootstrap files
  
</del>
 
EDIT:
Reasoning for not upgrading ApacheDS version:

I refrained from upgrading as there is currently an packaging issue with version AM27, for details check the apache issue tracker here: https://issues.apache.org/jira/browse/DIRSERVER-2389
